### PR TITLE
changing to latest released executable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,7 +9,7 @@ modules:
   use:
     - /g/data/vk83/modules
   load:
-    - coastri-roms/2025.06.000
+    - coastri-roms/2026.03.000
 
 ## -- model execution
 ncpus: 2


### PR DESCRIPTION
There is a new released executable - see [here](https://github.com/ACCESS-NRI/CoastRI-ROMS/releases/tag/2026.03.000).
This PR is for an update to point to this latest release.
The release does not change the ROMS version but there may be minor differences in the output (answer changing).
The updated executable is part of an update in slack and includes updated intel compiler (intel-oneapi-compilers@2025.2.0).

